### PR TITLE
dkim: Fix ed25519 signing

### DIFF
--- a/dkim/dkim_test.go
+++ b/dkim/dkim_test.go
@@ -27,7 +27,7 @@ GMot/L2x0IYyMLAz6oLWh2hm7zwtb0CgOrPo1ke44hFYnfc=
 -----END RSA PRIVATE KEY-----
 `
 
-const testEd25519PrivateKeyBase64 = "nWGxne/9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A="
+const testEd25519SeedBase64 = "nWGxne/9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A="
 
 var (
 	testPrivateKey        *rsa.PrivateKey
@@ -42,10 +42,11 @@ func init() {
 		panic(err)
 	}
 
-	testEd25519PrivateKey, err = base64.StdEncoding.DecodeString(testEd25519PrivateKeyBase64)
+	ed25519Seed, err := base64.StdEncoding.DecodeString(testEd25519SeedBase64)
 	if err != nil {
 		panic(err)
 	}
+	testEd25519PrivateKey = ed25519.NewKeyFromSeed(ed25519Seed)
 
 	now = func() time.Time {
 		return time.Unix(424242, 0)

--- a/dkim/sign.go
+++ b/dkim/sign.go
@@ -258,6 +258,12 @@ func NewSigner(options *SignOptions) (*Signer, error) {
 		}
 		hashed := hasher.Sum(nil)
 
+		// Don't pass Hash to Sign for ed25519 as it doesn't support it
+		// and will return an error ("ed25519: cannot sign hashed message").
+		if keyAlgo == "ed25519" {
+			hash = crypto.Hash(0)
+		}
+
 		sig, err := options.Signer.Sign(randReader, hashed, hash)
 		if err != nil {
 			closeReadWithError(err)

--- a/dkim/sign_ed25519_test.go
+++ b/dkim/sign_ed25519_test.go
@@ -1,0 +1,68 @@
+package dkim
+
+import (
+	"bytes"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+const signedEd25519MailString = "DKIM-Signature: a=ed25519-sha256; bh=2jUSOH9NhtVGCQWNr9BrIAPreKQjO6Sn7XIkfJ" + "\r\n" +
+	" " + "VOzv8=; c=simple/simple; d=football.example.com; h=From:To:Subject:Date:Mes" + "\r\n" +
+	" " + "sage-ID; s=brisbane; t=424242; v=1; b=ZduPZq83AOTqjhScIfHll6W90tMG1nf34a34Q" + "\r\n" +
+	" " + "XKat3iFtP7NQE/3AwnHOrcsR2r5nVNoW+LeZURpT2obCthPCw==;" + "\r\n" +
+	mailHeaderString +
+	"\r\n" +
+	mailBodyString
+
+func init() {
+	randReader = rand.New(rand.NewSource(42))
+}
+
+func TestSignEd25519(t *testing.T) {
+	r := strings.NewReader(mailString)
+	options := &SignOptions{
+		Domain:   "football.example.com",
+		Selector: "brisbane",
+		Signer:   testEd25519PrivateKey,
+	}
+
+	var b bytes.Buffer
+	if err := Sign(&b, r, options); err != nil {
+		t.Fatal("Expected no error while signing mail, got:", err)
+	}
+
+	if s := b.String(); s != signedEd25519MailString {
+		t.Errorf("Expected signed message to be \n%v\n but got \n%v", signedEd25519MailString, s)
+	}
+}
+
+func TestSignAndVerifyEd25519(t *testing.T) {
+	r := strings.NewReader(mailString)
+	options := &SignOptions{
+		Domain:   "football.example.com",
+		Selector: "brisbane",
+		Signer:   testEd25519PrivateKey,
+	}
+
+	var b bytes.Buffer
+	if err := Sign(&b, r, options); err != nil {
+		t.Fatal("Expected no error while signing mail, got:", err)
+	}
+
+	verifications, err := Verify(&b)
+	if err != nil {
+		t.Fatalf("Expected no error while verifying signature, got: %v", err)
+	}
+	if len(verifications) != 1 {
+		t.Error("Expected exactly one verification")
+	} else {
+		v := verifications[0]
+		if err := v.Err; err != nil {
+			t.Errorf("Expected no error when verifying signature, got: %v", err)
+		}
+		if v.Domain != options.Domain {
+			t.Errorf("Expected domain to be %q but got %q", options.Domain, v.Domain)
+		}
+	}
+}


### PR DESCRIPTION
Apparently, "other problems" were me concating keys in the wrong order. (ed25519.PrivateKey is seed+public, not public+seed).

Closes #14.