### PR TITLE
Fix dkim verification issues and dmarc alignment default

### DIFF
--- a/dkim/canonical.go
+++ b/dkim/canonical.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 )
 
+var rxReduceWS = regexp.MustCompile(`[ \t\r\n]+`)
+
 // Canonicalization is a canonicalization algorithm.
 type Canonicalization string
 
@@ -105,7 +107,6 @@ func (c *relaxedCanonicalizer) CanonicalizeHeader(s string) string {
 
 	var v string
 	if len(kv) > 1 {
-		rxReduceWS := regexp.MustCompile(`[ \t\r\n]+`)
 		v = rxReduceWS.ReplaceAllString(kv[1], " ")
 		v = strings.TrimSpace(v)
 

--- a/dkim/canonical.go
+++ b/dkim/canonical.go
@@ -2,6 +2,7 @@ package dkim
 
 import (
 	"io"
+	"regexp"
 	"strings"
 )
 
@@ -104,21 +105,10 @@ func (c *relaxedCanonicalizer) CanonicalizeHeader(s string) string {
 
 	var v string
 	if len(kv) > 1 {
-		v = kv[1]
-	}
-	lines := strings.Split(v, crlf)
-	lines[0] = strings.TrimLeft(lines[0], " \t")
+		rxReduceWS := regexp.MustCompile(`[ \t\r\n]+`)
+		v = rxReduceWS.ReplaceAllString(kv[1], " ")
+		v = strings.TrimSpace(v)
 
-	v = ""
-	for _, l := range lines {
-		if len(l) == 0 {
-			break
-		}
-
-		if l[0] == ' ' || l[0] == '\t' {
-			v += " "
-		}
-		v += strings.Trim(l, " \t")
 	}
 
 	return k + ":" + v + crlf

--- a/dkim/canonical_test.go
+++ b/dkim/canonical_test.go
@@ -89,6 +89,10 @@ var relaxedCanonicalizerHeaderTests = []struct {
 		"Subject \t:\t Kimi \t \r\n No \t\r\n Na Wa\r\n",
 		"subject:Kimi No Na Wa\r\n",
 	},
+	{
+		"Subject \t:\t Ki \tmi \t \r\n No \t\r\n Na Wa\r\n",
+		"subject:Ki mi No Na Wa\r\n",
+	},
 }
 
 func TestRelaxedCanonicalizer_CanonicalizeHeader(t *testing.T) {

--- a/dkim/query.go
+++ b/dkim/query.go
@@ -101,6 +101,7 @@ func parsePublicKey(s string) (*queryResult, error) {
 	if p == "" {
 		return nil, permFailError("key revoked")
 	}
+	p = strings.ReplaceAll(p, " ", "")
 	b, err := base64.StdEncoding.DecodeString(p)
 	if err != nil {
 		return nil, permFailError("key syntax error: " + err.Error())

--- a/dmarc/lookup.go
+++ b/dmarc/lookup.go
@@ -65,6 +65,7 @@ func Parse(txt string) (*Record, error) {
 		return nil, err
 	}
 
+	rec.DKIMAlignment = AlignmentRelaxed
 	if adkim, ok := params["adkim"]; ok {
 		rec.DKIMAlignment, err = parseAlignmentMode(adkim, "adkim")
 		if err != nil {
@@ -72,6 +73,7 @@ func Parse(txt string) (*Record, error) {
 		}
 	}
 
+	rec.SPFAlignment = AlignmentRelaxed
 	if aspf, ok := params["aspf"]; ok {
 		rec.SPFAlignment, err = parseAlignmentMode(aspf, "aspf")
 		if err != nil {


### PR DESCRIPTION
Change-Id: I0e023a602004bb18f573321c5811d1c876312663
Default DMARC policy is relax
https://blog.returnpath.com/demystifying-the-dmarc-record/
Reduce all sequences of WSP within a line to a single SP character.
https://tools.wordtothewise.com/rfc/6376#section-3.4