### PR TITLE
dkim: remove Signer.SignatureValue

### DIFF
--- a/dkim/sign.go
+++ b/dkim/sign.go
@@ -305,15 +305,6 @@ func (s *Signer) Signature() string {
 	return formatSignature(s.sigParams)
 }
 
-// SignatureValue returns value of the DKIM-Signature header field. It can
-// only be called after a successful Signer.Close call.
-func (s *Signer) SignatureValue() string {
-	if s.sigParams == nil {
-		panic("dkim: Signer.SignatureValue must only be called after a succesful Signer.Close")
-	}
-	return formatHeaderParams(s.sigParams)
-}
-
 // Sign signs a message. It reads it from r and writes the signed version to w.
 func Sign(w io.Writer, r io.Reader, options *SignOptions) error {
 	s, err := NewSigner(options)


### PR DESCRIPTION
The header key is case-sensitive and the folding cannot be changed.
Remove this function as it's too easy to get it wrong [1].

This is a breaking change.

[1]: https://github.com/foxcpp/maddy/issues/187

cc @foxcpp 