### PR TITLE
Export selector and DNS response via Verification

### DIFF
--- a/cmd/dkim-verify/main.go
+++ b/cmd/dkim-verify/main.go
@@ -15,9 +15,9 @@ func main() {
 
 	for _, v := range verifications {
 		if v.Err == nil {
-			log.Printf("Valid signature for %v", v.Domain)
+			log.Printf("Valid signature for %v (selector=%s) (algo=%s)", v.Domain, v.Selector, v.QueryResult.KeyAlgo)
 		} else {
-			log.Printf("Invalid signature for %v: %v", v.Domain, v.Err)
+			log.Printf("Valid signature for %v (selector=%s) (algo=%s): %v", v.Domain, v.Selector, v.QueryResult.KeyAlgo, v.Err)
 		}
 	}
 }

--- a/cmd/dkim-verify/main.go
+++ b/cmd/dkim-verify/main.go
@@ -17,7 +17,7 @@ func main() {
 		if v.Err == nil {
 			log.Printf("Valid signature for %v (selector=%s) (algo=%s)", v.Domain, v.Selector, v.QueryResult.KeyAlgo)
 		} else {
-			log.Printf("Valid signature for %v (selector=%s) (algo=%s): %v", v.Domain, v.Selector, v.QueryResult.KeyAlgo, v.Err)
+			log.Printf("Invalid signature for %v (selector=%s) (algo=%s): %v", v.Domain, v.Selector, v.QueryResult.KeyAlgo, v.Err)
 		}
 	}
 }


### PR DESCRIPTION
This makes debugging much easier. It can be difficult to debug issues
as the verification struct does not contain all information used for
the verification like the public key or the selector. If you
change the DNS record and don't know if DNS is still cached further
information can help.

Thank you for writing this library!

kmille