### PR TITLE
dkim: compare with strings.EqualFold instead of ToLower

### DIFF
--- a/dkim/header.go
+++ b/dkim/header.go
@@ -149,13 +149,12 @@ func newHeaderPicker(h header) *headerPicker {
 }
 
 func (p *headerPicker) Pick(key string) string {
-	key = strings.ToLower(key)
 	at := p.picked[key]
 	for i := len(p.h) - 1; i >= 0; i-- {
 		kv := p.h[i]
 		k, _ := parseHeaderField(kv)
 
-		if strings.ToLower(k) != key {
+		if !strings.EqualFold(k, key) {
 			continue
 		}
 

--- a/dkim/verify.go
+++ b/dkim/verify.go
@@ -241,7 +241,7 @@ func verify(h header, r io.Reader, sigField, sigValue string, options *VerifyOpt
 	headerKeys := parseTagList(params["h"])
 	ok := false
 	for _, k := range headerKeys {
-		if strings.ToLower(k) == "from" {
+		if strings.EqualFold(k, "from") {
 			ok = true
 			break
 		}


### PR DESCRIPTION
It doesn't allocate a new string each time.

Fixes #48