### PR TITLE
dkim: Only compile regex once

### DIFF
--- a/dkim/verify.go
+++ b/dkim/verify.go
@@ -457,6 +457,8 @@ func stripWhitespace(s string) string {
 	}, s)
 }
 
+var sigRegex = regexp.MustCompile(`(b\s*=)[^;]+`)
+
 func removeSignature(s string) string {
-	return regexp.MustCompile(`(b\s*=)[^;]+`).ReplaceAllString(s, "$1")
+	return sigRegex.ReplaceAllString(s, "$1")
 }


### PR DESCRIPTION
Only compile the regex for removing the b= value once during verification, reducing allocations & improving performance.

```
goos: windows
goarch: amd64
pkg: github.com/emersion/go-msgauth/dkim
cpu: AMD Ryzen 5 5600X 6-Core Processor
        │ original.txt │          regex-static.txt          │
        │    sec/op    │   sec/op     vs base               │
Name-12    47.95µ ± 0%   45.78µ ± 1%  -4.53% (p=0.000 n=10)

        │ original.txt │           regex-static.txt           │
        │     B/op     │     B/op      vs base                │
Name-12   18.95Ki ± 0%   16.14Ki ± 0%  -14.81% (p=0.000 n=10)

        │ original.txt │          regex-static.txt          │
        │  allocs/op   │ allocs/op   vs base                │
Name-12     186.0 ± 0%   157.0 ± 0%  -15.59% (p=0.000 n=10)

```