### PR TITLE
perf: Allocation reduction

### DIFF
--- a/authres/parse.go
+++ b/authres/parse.go
@@ -294,9 +294,9 @@ func parseResult(s string) (Result, error) {
 }
 
 func parseParam(s string) (k string, v string, err error) {
-	index := strings.Index(s, "=")
-	if index == -1 {
+	k, v, ok := strings.Cut(s, "=")
+	if !ok {
 		return "", "", errors.New("msgauth: malformed authentication method and value")
 	}
-	return strings.ToLower(strings.TrimSpace(s[:index])), strings.TrimSpace(s[index+1:]), nil
+	return strings.ToLower(strings.TrimSpace(k)), strings.TrimSpace(v), nil
 }

--- a/authres/parse.go
+++ b/authres/parse.go
@@ -294,9 +294,9 @@ func parseResult(s string) (Result, error) {
 }
 
 func parseParam(s string) (k string, v string, err error) {
-	kv := strings.SplitN(s, "=", 2)
-	if len(kv) != 2 {
+	index := strings.Index(s, "=")
+	if index == -1 {
 		return "", "", errors.New("msgauth: malformed authentication method and value")
 	}
-	return strings.ToLower(strings.TrimSpace(kv[0])), strings.TrimSpace(kv[1]), nil
+	return strings.ToLower(strings.TrimSpace(s[:index])), strings.TrimSpace(s[index+1:]), nil
 }

--- a/dkim/canonical.go
+++ b/dkim/canonical.go
@@ -110,13 +110,13 @@ func (c *simpleCanonicalizer) CanonicalizeBody(w io.Writer) io.WriteCloser {
 type relaxedCanonicalizer struct{}
 
 func (c *relaxedCanonicalizer) CanonicalizeHeader(s string) string {
-	index := strings.Index(s, ":")
-	if index == -1 {
+	k, v, ok := strings.Cut(s, ":")
+	if !ok {
 		return strings.TrimSpace(strings.ToLower(s)) + ":" + crlf
 	}
 
-	k := strings.TrimSpace(strings.ToLower(s[:index]))
-	v := strings.Join(strings.FieldsFunc(s[index+1:], func(r rune) bool {
+	k = strings.TrimSpace(strings.ToLower(k))
+	v = strings.Join(strings.FieldsFunc(v, func(r rune) bool {
 		return r == ' ' || r == '\t' || r == '\n' || r == '\r'
 	}), " ")
 	return k + ":" + v + crlf

--- a/dkim/canonical.go
+++ b/dkim/canonical.go
@@ -2,11 +2,8 @@ package dkim
 
 import (
 	"io"
-	"regexp"
 	"strings"
 )
-
-var rxReduceWS = regexp.MustCompile(`[ \t\r\n]+`)
 
 // Canonicalization is a canonicalization algorithm.
 type Canonicalization string
@@ -119,8 +116,9 @@ func (c *relaxedCanonicalizer) CanonicalizeHeader(s string) string {
 	}
 
 	k := strings.TrimSpace(strings.ToLower(s[:index]))
-	v := rxReduceWS.ReplaceAllString(s[index+1:], " ")
-	v = strings.TrimSpace(v)
+	v := strings.Join(strings.FieldsFunc(s[index+1:], func(r rune) bool {
+		return r == ' ' || r == '\t' || r == '\n' || r == '\r'
+	}), " ")
 	return k + ":" + v + crlf
 }
 

--- a/dkim/canonical.go
+++ b/dkim/canonical.go
@@ -113,16 +113,14 @@ func (c *simpleCanonicalizer) CanonicalizeBody(w io.Writer) io.WriteCloser {
 type relaxedCanonicalizer struct{}
 
 func (c *relaxedCanonicalizer) CanonicalizeHeader(s string) string {
-	kv := strings.SplitN(s, ":", 2)
-
-	k := strings.TrimSpace(strings.ToLower(kv[0]))
-
-	var v string
-	if len(kv) > 1 {
-		v = rxReduceWS.ReplaceAllString(kv[1], " ")
-		v = strings.TrimSpace(v)
+	index := strings.Index(s, ":")
+	if index == -1 {
+		return strings.TrimSpace(strings.ToLower(s)) + ":" + crlf
 	}
 
+	k := strings.TrimSpace(strings.ToLower(s[:index]))
+	v := rxReduceWS.ReplaceAllString(s[index+1:], " ")
+	v = strings.TrimSpace(v)
 	return k + ":" + v + crlf
 }
 

--- a/dkim/header.go
+++ b/dkim/header.go
@@ -66,28 +66,27 @@ func foldHeaderField(kv string) string {
 	return fold.String() + crlf
 }
 
-func parseHeaderField(s string) (k string, v string) {
-	kv := strings.SplitN(s, ":", 2)
-	k = strings.TrimSpace(kv[0])
-	if len(kv) > 1 {
-		v = strings.TrimSpace(kv[1])
+func parseHeaderField(s string) (string, string) {
+	index := strings.Index(s, ":")
+	if index == -1 {
+		return strings.TrimSpace(s), ""
 	}
-	return
+	return strings.TrimSpace(s[:index]), strings.TrimSpace(s[index+1:])
 }
 
 func parseHeaderParams(s string) (map[string]string, error) {
 	pairs := strings.Split(s, ";")
 	params := make(map[string]string)
 	for _, s := range pairs {
-		kv := strings.SplitN(s, "=", 2)
-		if len(kv) != 2 {
+		index := strings.Index(s, "=")
+		if index == -1 {
 			if strings.TrimSpace(s) == "" {
 				continue
 			}
 			return params, errors.New("dkim: malformed header params")
 		}
 
-		params[strings.TrimSpace(kv[0])] = strings.TrimSpace(kv[1])
+		params[strings.TrimSpace(s[:index])] = strings.TrimSpace(s[index+1:])
 	}
 	return params, nil
 }

--- a/dkim/header.go
+++ b/dkim/header.go
@@ -67,26 +67,23 @@ func foldHeaderField(kv string) string {
 }
 
 func parseHeaderField(s string) (string, string) {
-	index := strings.Index(s, ":")
-	if index == -1 {
-		return strings.TrimSpace(s), ""
-	}
-	return strings.TrimSpace(s[:index]), strings.TrimSpace(s[index+1:])
+	key, value, _ := strings.Cut(s, ":")
+	return strings.TrimSpace(key), strings.TrimSpace(value)
 }
 
 func parseHeaderParams(s string) (map[string]string, error) {
 	pairs := strings.Split(s, ";")
 	params := make(map[string]string)
 	for _, s := range pairs {
-		index := strings.Index(s, "=")
-		if index == -1 {
+		key, value, ok := strings.Cut(s, "=")
+		if !ok {
 			if strings.TrimSpace(s) == "" {
 				continue
 			}
 			return params, errors.New("dkim: malformed header params")
 		}
 
-		params[strings.TrimSpace(s[:index])] = strings.TrimSpace(s[index+1:])
+		params[strings.TrimSpace(key)] = strings.TrimSpace(value)
 	}
 	return params, nil
 }

--- a/dkim/verify.go
+++ b/dkim/verify.go
@@ -293,12 +293,13 @@ func verify(h header, r io.Reader, sigField, sigValue string, options *VerifyOpt
 	}
 
 	// Parse algos
-	algos := strings.SplitN(stripWhitespace(params["a"]), "-", 2)
-	if len(algos) != 2 {
+	aNoWs := stripWhitespace(params["a"])
+	index := strings.Index(aNoWs, "-")
+	if index == -1 {
 		return verif, permFailError("malformed algorithm name")
 	}
-	keyAlgo := algos[0]
-	hashAlgo := algos[1]
+	keyAlgo := aNoWs[:index]
+	hashAlgo := aNoWs[index+1:]
 
 	// Check hash algo
 	if res.HashAlgos != nil {

--- a/dkim/verify.go
+++ b/dkim/verify.go
@@ -293,13 +293,10 @@ func verify(h header, r io.Reader, sigField, sigValue string, options *VerifyOpt
 	}
 
 	// Parse algos
-	aNoWs := stripWhitespace(params["a"])
-	index := strings.Index(aNoWs, "-")
-	if index == -1 {
+	keyAlgo, hashAlgo, ok := strings.Cut(stripWhitespace(params["a"]), "-")
+	if !ok {
 		return verif, permFailError("malformed algorithm name")
 	}
-	keyAlgo := aNoWs[:index]
-	hashAlgo := aNoWs[index+1:]
 
 	// Check hash algo
 	if res.HashAlgos != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/emersion/go-msgauth
 
-go 1.12
+go 1.18
 
 require (
 	github.com/emersion/go-message v0.17.0 // indirect


### PR DESCRIPTION
Improve performance/reduce allocations of within DKIM & Authres with changes:

Replace `strings.SplitN` where `N=2` with `strings.Index`, as this does not complicate the code, but does have the advantage of not needing to allocate a slice of strings with. These changes would look even more simple through the use of `strings.Cut`, however this was added in Go 1.18 and I didn't want to force a minimum version bump for the sake of this change (Although 1.18 is now out of support) - If this would be preferred I can do this instead.

Additional calls to `SplitN` where `N=2` exist in the codebase, but they are in the milter code, or they are in code that has no unit tests so I have not made any changes there.

I have replaced the use of a regex to reduce the whitespace within header canonicalization, as regex within Go can be quite slow and given the simplistic nature of the regex it can be easily replaced by using `FieldsFunc` and `Join`.

```
$ benchstat.exe master.txt split-enhancements.txt
goos: windows
goarch: amd64
pkg: github.com/emersion/go-msgauth/authres
cpu: AMD Ryzen 5 5600X 6-Core Processor
                │ master.txt  │       split-enhancements.txt        │
                │   sec/op    │   sec/op     vs base                │
AuthresParse-12   8.285µ ± 6%   7.423µ ± 5%  -10.40% (p=0.000 n=10)

                │  master.txt  │        split-enhancements.txt        │
                │     B/op     │     B/op      vs base                │
AuthresParse-12   8.297Ki ± 0%   7.391Ki ± 0%  -10.92% (p=0.000 n=10)

                │ master.txt  │       split-enhancements.txt       │
                │  allocs/op  │ allocs/op   vs base                │
AuthresParse-12   115.00 ± 0%   86.00 ± 0%  -25.22% (p=0.000 n=10)

pkg: github.com/emersion/go-msgauth/dkim
                                           │  master.txt  │       split-enhancements.txt        │
                                           │    sec/op    │   sec/op     vs base                │
RelaxedCanonicalizer_CanonicalizeHeader-12   3164.0n ± 6%   892.1n ± 6%  -71.81% (p=0.000 n=10)
Verify-12                                     46.66µ ± 6%   44.68µ ± 7%   -4.25% (p=0.019 n=10)

                                           │  master.txt  │        split-enhancements.txt        │
                                           │     B/op     │     B/op      vs base                │
RelaxedCanonicalizer_CanonicalizeHeader-12     508.0 ± 0%     416.0 ± 0%  -18.11% (p=0.000 n=10)
Verify-12                                    16.16Ki ± 0%   14.83Ki ± 0%   -8.20% (p=0.000 n=10)

                                           │ master.txt │       split-enhancements.txt       │
                                           │ allocs/op  │ allocs/op   vs base                │
RelaxedCanonicalizer_CanonicalizeHeader-12   28.00 ± 0%   16.00 ± 0%  -42.86% (p=0.000 n=10)
Verify-12                                    157.0 ± 0%   115.0 ± 0%  -26.75% (p=0.000 n=10)
```