### PR TITLE
dkim: reject tag-lists with duplicate tag names

### DIFF
--- a/dkim/header.go
+++ b/dkim/header.go
@@ -83,7 +83,12 @@ func parseHeaderParams(s string) (map[string]string, error) {
 			return params, errors.New("dkim: malformed header params")
 		}
 
-		params[strings.TrimSpace(key)] = strings.TrimSpace(value)
+		trimmedKey := strings.TrimSpace(key)
+		_, present := params[trimmedKey]
+		if present {
+			return params, errors.New("dkim: duplicate tag name")
+		}
+		params[trimmedKey] = strings.TrimSpace(value)
 	}
 	return params, nil
 }

--- a/dkim/query.go
+++ b/dkim/query.go
@@ -100,7 +100,7 @@ func queryDNSTXT(domain, selector string, txtLookup txtLookupFunc) (*queryResult
 func parsePublicKey(s string) (*queryResult, error) {
 	params, err := parseHeaderParams(s)
 	if err != nil {
-		return nil, permFailError("key syntax error: " + err.Error())
+		return nil, permFailError("key record error: " + err.Error())
 	}
 
 	res := new(queryResult)


### PR DESCRIPTION
`dkim` is repeated in the error messages:
```
2025/01/10 19:48:22 Invalid signature for lebihan.pl: dkim: key record error: dkim: duplicate tag name
```
```
2025/01/10 19:49:04 Invalid signature for : dkim: malformed signature tags: dkim: duplicate tag name
```
However, I believe that this issue should be fixed in another PR.