### PR TITLE
authres: fix parsing AR headers with ";" in comments

### DIFF
--- a/authres/parse_test.go
+++ b/authres/parse_test.go
@@ -32,6 +32,14 @@ var parseTests = []msgauthTest{
 			&AuthResult{Value: ResultPass, Auth: "sender@example.com"},
 		},
 	},
+	{
+		value: `mail.club1.fr;
+        dkim=pass (2048-bit key; unprotected) header.d=free.fr header.i=@free.fr header.a=rsa-sha256 header.s=smtp-20201208 header.b=OnHOkkuR`,
+		identifier: "mail.club1.fr",
+		results: []Result{
+			&DKIMResult{Value: ResultPass, Domain: "free.fr", Identifier: "@free.fr"},
+		},
+	},
 }
 
 func TestParse(t *testing.T) {
@@ -46,7 +54,7 @@ func TestParse(t *testing.T) {
 		} else {
 			for i := 0; i < len(results); i++ {
 				if !reflect.DeepEqual(test.results[i], results[i]) {
-					t.Errorf("Expected result to be \n%v\n but got \n%v", test.results[i], results[i])
+					t.Errorf("Expected result to be \n%#v\n but got \n%#v", test.results[i], results[i])
 				}
 			}
 		}


### PR DESCRIPTION
To ignore the comments, we first remove them from the header's value string, before splitting it by ";". This allows parsing Authentication-Results headers created by OpenDKIM.

Fixes: #74

I just saw that #53 should also fix this, it is IMO better to merge it instead instead of mine.
