### PR TITLE
New: `GenSignature()`

### DIFF
--- a/dkim/sign.go
+++ b/dkim/sign.go
@@ -333,7 +333,7 @@ func Sign(w io.Writer, r io.Reader, options *SignOptions) error {
 	return err
 }
 
-// GenSignature reads message from r and return generated raw signature (without `DKIM-Signature:` header key).
+// GenSignature reads message from r and return signature (without `DKIM-Signature:` header key).
 func GenSignature(r io.Reader, options *SignOptions) (signature string, err error) {
 	s, err := NewSigner(options)
 	if err != nil {

--- a/dkim/sign.go
+++ b/dkim/sign.go
@@ -333,7 +333,7 @@ func Sign(w io.Writer, r io.Reader, options *SignOptions) error {
 	return err
 }
 
-// GenSignature reads message from r and return signature (without `DKIM-Signature:` header key).
+// GenSignature reads message from r and returns generated signature (without `DKIM-Signature:` header key).
 func GenSignature(r io.Reader, options *SignOptions) (signature string, err error) {
 	s, err := NewSigner(options)
 	if err != nil {

--- a/dkim/sign_test.go
+++ b/dkim/sign_test.go
@@ -8,29 +8,33 @@ import (
 	"testing"
 )
 
-const mailHeaderString = "From: Joe SixPack <joe@football.example.com>\r\n" +
-	"To: Suzie Q <suzie@shopping.example.net>\r\n" +
-	"Subject: Is dinner ready?\r\n" +
-	"Date: Fri, 11 Jul 2003 21:00:37 -0700 (PDT)\r\n" +
-	"Message-ID: <20030712040037.46341.5F8J@football.example.com>\r\n"
+const (
+	mailHeaderString = "From: Joe SixPack <joe@football.example.com>\r\n" +
+		"To: Suzie Q <suzie@shopping.example.net>\r\n" +
+		"Subject: Is dinner ready?\r\n" +
+		"Date: Fri, 11 Jul 2003 21:00:37 -0700 (PDT)\r\n" +
+		"Message-ID: <20030712040037.46341.5F8J@football.example.com>\r\n"
 
-const mailBodyString = "Hi.\r\n" +
-	"\r\n" +
-	"We lost the game. Are you hungry yet?\r\n" +
-	"\r\n" +
-	"Joe."
+	mailBodyString = "Hi.\r\n" +
+		"\r\n" +
+		"We lost the game. Are you hungry yet?\r\n" +
+		"\r\n" +
+		"Joe."
 
-const mailString = mailHeaderString + "\r\n" + mailBodyString
+	mailString = mailHeaderString + "\r\n" + mailBodyString
 
-const signedMailString = "DKIM-Signature: a=rsa-sha256; bh=2jUSOH9NhtVGCQWNr9BrIAPreKQjO6Sn7XIkfJVOzv8=;" + "\r\n" +
-	" " + "c=simple/simple; d=example.org; h=From:To:Subject:Date:Message-ID;" + "\r\n" +
-	" " + "s=brisbane; t=424242; v=1;" + "\r\n" +
-	" " + "b=MobyyDTeHhMhNJCEI6ATNK63ZQ7deSXK9umyzAvYwFqE6oGGvlQBQwqr1aC11hWpktjMLP1/" + "\r\n" +
-	" " + "m0PBi9v7cRLKMXXBIv2O0B1mIWdZPqd9jveRJqKzCb7SpqH2u5kK6i2vZI639ENTQzRQdxSAGXc" + "\r\n" +
-	" " + "PcPYjrgkqj7xklnrNBs0aIUA=" + "\r\n" +
-	mailHeaderString +
-	"\r\n" +
-	mailBodyString
+	signed = "a=rsa-sha256; bh=2jUSOH9NhtVGCQWNr9BrIAPreKQjO6Sn7XIkfJVOzv8=;" + "\r\n" +
+		" " + "c=simple/simple; d=example.org; h=From:To:Subject:Date:Message-ID;" + "\r\n" +
+		" " + "s=brisbane; t=424242; v=1;" + "\r\n" +
+		" " + "b=MobyyDTeHhMhNJCEI6ATNK63ZQ7deSXK9umyzAvYwFqE6oGGvlQBQwqr1aC11hWpktjMLP1/" + "\r\n" +
+		" " + "m0PBi9v7cRLKMXXBIv2O0B1mIWdZPqd9jveRJqKzCb7SpqH2u5kK6i2vZI639ENTQzRQdxSAGXc" + "\r\n" +
+		" " + "PcPYjrgkqj7xklnrNBs0aIUA="
+
+	signedMailString = "DKIM-Signature: " + signed + "\r\n" +
+		mailHeaderString +
+		"\r\n" +
+		mailBodyString
+)
 
 func init() {
 	randReader = rand.New(rand.NewSource(42))
@@ -50,6 +54,24 @@ func TestSign(t *testing.T) {
 	}
 
 	if s := b.String(); s != signedMailString {
+		t.Errorf("Expected signed message to be \n%v\n but got \n%v", signedMailString, s)
+	}
+}
+
+func TestGenSignature(t *testing.T) {
+	r := strings.NewReader(mailString)
+	options := &SignOptions{
+		Domain:   "example.org",
+		Selector: "brisbane",
+		Signer:   testPrivateKey,
+	}
+
+	s, err := GenSignature(r, options)
+	if err != nil {
+		t.Fatal("Expected no error while signing mail, got:", err)
+	}
+
+	if s != signed {
 		t.Errorf("Expected signed message to be \n%v\n but got \n%v", signedMailString, s)
 	}
 }


### PR DESCRIPTION
This PR introduces a new function with test:
```
// GenSignature reads message from r and return signature (without `DKIM-Signature:` header key).
GenSignature(r io.Reader, options *SignOptions) (signature string, err error)
```

## Why we need this new function?

While developing a milter program with https://github.com/emersion/go-milter or its fork, we need to insert the `DKIM-Signature:` header, in this case we need `go-msgauth` library to return the generated dkim signature (header value) instead of a new email message with this header. This new function simplifies such task and saves some memory.