### PR TITLE
Fix issue where b= appearing in a copied header breaks validation.

### DIFF
--- a/dkim/verify.go
+++ b/dkim/verify.go
@@ -455,7 +455,9 @@ func stripWhitespace(s string) string {
 	}, s)
 }
 
-var sigRegex = regexp.MustCompile(`(b\s*=)[^;]+`)
+// Removing the content of the b= field. Not 100% correct as the b= could
+// be the first field in the signature and so not preceded by a semicolon.
+var sigRegex = regexp.MustCompile(`(;\s*b\s*=)[^;]+`)
 
 func removeSignature(s string) string {
 	return sigRegex.ReplaceAllString(s, "$1")

--- a/dkim/verify_test.go
+++ b/dkim/verify_test.go
@@ -294,3 +294,29 @@ func TestVerify_tooManySignatures(t *testing.T) {
 		t.Fatalf("Expected %v verifications, got %v", options.MaxVerifications, len(verifs))
 	}
 }
+
+const withCopiedHeadersMailString = `DKIM-Signature: a=rsa-sha256; bh=cSd2xJLZ1w6BVX02p/7+LEUN7cKokyc8EcnSGvVt6/U=;
+ c=simple/simple; d=example.org; h=Date:From:Subject; s=brisbane; t=424242;
+ v=1; z=From:Steve=20b=20=3C
+ |Subject:Is=20dinner=20;
+ b=deBHDj9iug224Bpdsz05taGJ4YEz2ciqcVeLe+5NKDSk0J6gqZBLm/T0z1WXB0+LtsjL9KfJ
+ +QXpDSNQe6JvvZSv2e40QNUbeuF5AqT8wgyxAmJIDD4UU08XChBZKKqc2nmxkQG0zpHBCQ+ljwz
+ q3la34vyXvPXqSLFKQDdmCV4=
+Date: Fri, 11 Jul 2003 21:00:37 -0700 (PDT)
+From: Steve b <steve@example.com>
+Subject: Is dinner ready?
+
+Somebody once told me.
+`
+
+func TestVerify_withCopiedHeaders(t *testing.T) {
+	r := strings.NewReader(withCopiedHeadersMailString)
+	verifications, err := Verify(r)
+	if err != nil {
+		t.Fatalf("Expected no error while verifying signature, got: %v", err)
+	}
+	v := verifications[0]
+	if v.Err != nil {
+		t.Errorf("Expected no error in signature, got: %v", v.Err)
+	}
+}


### PR DESCRIPTION
Minor change to regex used to clear the b=field during validation to avoid false matches in other fields.

Fixes #77 