### PR TITLE
dkim: add support for generating z= field in signature

### DIFF
--- a/dkim/header.go
+++ b/dkim/header.go
@@ -170,3 +170,50 @@ func (p *headerPicker) Pick(key string) string {
 
 	return ""
 }
+
+const upperhex = "0123456789ABCDEF"
+
+// qpHeaderValue encodes strings as described in RFC 6376 #2.11,
+// additionally escaping "|"
+func qpHeaderValue(p []byte) string {
+	var w bytes.Buffer
+	var n int
+	for i, b := range p {
+		switch {
+		case b >= '!' && b <= ':':
+			continue
+		case b == '=':
+			continue
+		case b >= '>' && b <= '{':
+			continue
+		case b == '}':
+			continue
+		case b == '~':
+			continue
+		}
+		if i > n {
+			_, _ = w.Write(p[n:i])
+			n = i
+		}
+		w.WriteByte('=')
+		w.WriteByte(upperhex[b>>4])
+		w.WriteByte(upperhex[b&0x0f])
+		n++
+	}
+	return w.String()
+}
+
+func copyHeaders(names []string, h header) []string {
+	want := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		want[strings.ToLower(name)] = struct{}{}
+	}
+	var copied []string
+	for _, kv := range h {
+		k, v := parseHeaderField(kv)
+		if _, ok := want[strings.ToLower(k)]; ok {
+			copied = append(copied, k+":"+qpHeaderValue([]byte(v)))
+		}
+	}
+	return copied
+}

--- a/dkim/header.go
+++ b/dkim/header.go
@@ -180,15 +180,15 @@ func qpHeaderValue(p []byte) string {
 	var n int
 	for i, b := range p {
 		switch {
-		case b >= '!' && b <= ':':
+		case b >= '!' && b <= ':': // %x21-3A
 			continue
-		case b == '=':
+		case b == '<': // %x3c
 			continue
-		case b >= '>' && b <= '{':
+		case b >= '>' && b <= '{': // %x3e - %x7b
 			continue
-		case b == '}':
+		case b == '}': // %x7d
 			continue
-		case b == '~':
+		case b == '~': // %x7e
 			continue
 		}
 		if i > n {
@@ -200,6 +200,7 @@ func qpHeaderValue(p []byte) string {
 		w.WriteByte(upperhex[b&0x0f])
 		n++
 	}
+	w.Write(p[n:])
 	return w.String()
 }
 

--- a/dkim/header_test.go
+++ b/dkim/header_test.go
@@ -157,3 +157,12 @@ func TestFoldHeaderField(t *testing.T) {
 		t.Errorf("Extra black line added in header:\n Actual:\n ---Start--- %v ---End---\nExpected: \n ---Start--- %v ---End---\n", folded, expected)
 	}
 }
+
+func TestQpHeaderValue(t *testing.T) {
+	header := "Suzie Q;| <suzie@shopping.example.net>"
+	want := "Suzie=20Q=3B=7C=20<suzie@shopping.example.net>"
+	got := qpHeaderValue([]byte(header))
+	if got != want {
+		t.Errorf("got = %q, want %q", got, want)
+	}
+}

--- a/dkim/sign.go
+++ b/dkim/sign.go
@@ -68,6 +68,9 @@ type SignOptions struct {
 	//
 	// If nil, it is implicitly defined as QueryMethodDNSTXT.
 	QueryMethods []QueryMethod
+
+	// A list of header fields to copy into the z= field of the signature.
+	CopyHeaderKeys []string
 }
 
 // Signer generates a DKIM signature.
@@ -200,7 +203,7 @@ func NewSigner(options *SignOptions) (*Signer, error) {
 			//"l": "", // TODO
 			"s": options.Selector,
 			"t": formatTime(now()),
-			//"z": "", // TODO
+			//"z": "",
 		}
 
 		var headerKeys []string
@@ -228,6 +231,11 @@ func NewSigner(options *SignOptions) (*Signer, error) {
 
 		if !options.Expiration.IsZero() {
 			params["x"] = formatTime(options.Expiration)
+		}
+
+		if options.CopyHeaderKeys != nil {
+			copiedHeaders := copyHeaders(options.CopyHeaderKeys, h)
+			params["z"] = strings.Join(copiedHeaders, "\r\n |")
 		}
 
 		// Hash and sign headers

--- a/dkim/sign_test.go
+++ b/dkim/sign_test.go
@@ -164,7 +164,7 @@ func TestSign_invalidOptions(t *testing.T) {
 }
 
 func TestSign_copyHeaders(t *testing.T) {
-	wantZ := "z=To:Suzie=20Q=20=3C\r\n |Subject:Is=20dinner=20;\r\n"
+	wantZ := "z=To:Suzie=20Q=20<suzie@shopping.example.net>\r\n |Subject:Is=20dinner=20ready?;"
 	r := strings.NewReader(mailString)
 	options := &SignOptions{
 		Domain:         "example.org",

--- a/dkim/sign_test.go
+++ b/dkim/sign_test.go
@@ -162,3 +162,38 @@ func TestSign_invalidOptions(t *testing.T) {
 	}
 	options.HeaderKeys = nil
 }
+
+func TestSign_copyHeaders(t *testing.T) {
+	wantZ := "z=To:Suzie=20Q=20=3C\r\n |Subject:Is=20dinner=20;\r\n"
+	r := strings.NewReader(mailString)
+	options := &SignOptions{
+		Domain:         "example.org",
+		Selector:       "brisbane",
+		Signer:         testPrivateKey,
+		CopyHeaderKeys: []string{"Subject", "To"},
+	}
+	var b bytes.Buffer
+	if err := Sign(&b, r, options); err != nil {
+		t.Fatal("Expected no error while signing mail, got:", err)
+	}
+
+	if !strings.Contains(b.String(), wantZ) {
+		t.Error("Expected signed message to contain z= field")
+	}
+
+	verifications, err := Verify(&b)
+	if err != nil {
+		t.Fatalf("Expected no error while verifying signature, got: %v", err)
+	}
+	if len(verifications) != 1 {
+		t.Error("Expected exactly one verification")
+	} else {
+		v := verifications[0]
+		if err := v.Err; err != nil {
+			t.Errorf("Expected no error when verifying signature, got: %v", err)
+		}
+		if v.Domain != options.Domain {
+			t.Errorf("Expected domain to be %q but got %q", options.Domain, v.Domain)
+		}
+	}
+}


### PR DESCRIPTION
Adds a `CopyHeaderKeys` to SignOptions. If set then those headers will be included in the z= field of the generated signature.