### PR TITLE
Add BIMI support to Authentication-Results parsing

### DIFF
--- a/authres/format.go
+++ b/authres/format.go
@@ -41,6 +41,8 @@ func resultMethod(r Result) string {
 		return "spf"
 	case *DMARCResult:
 		return "dmarc"
+	case *BIMIResult:
+		return "bimi"
 	case *GenericResult:
 		return r.Method
 	default:

--- a/authres/msgauth_test.go
+++ b/authres/msgauth_test.go
@@ -85,18 +85,18 @@ var msgauthTests = []msgauthTest{
 	},
 	{
 		value: "example.com;" +
-			" bimi=pass header.d=mail-router.example.net",
+			" bimi=pass header.d=mail-router.example.net header.selector=selector1",
 		identifier: "example.com",
 		results: []Result{
-			&BIMIResult{Value: ResultPass, Domain: "mail-router.example.net"},
+			&BIMIResult{Value: ResultPass, Domain: "mail-router.example.net", Selector: "selector1"},
 		},
 	},
 	{
 		value: "example.com;" +
-			" bimi=fail header.d=example.com",
+			" bimi=fail header.d=example.com header.selector=selector1",
 		identifier: "example.com",
 		results: []Result{
-			&BIMIResult{Value: ResultFail, Domain: "example.com"},
+			&BIMIResult{Value: ResultFail, Domain: "example.com", Selector: "selector1"},
 		},
 	},
 }

--- a/authres/msgauth_test.go
+++ b/authres/msgauth_test.go
@@ -83,4 +83,20 @@ var msgauthTests = []msgauthTest{
 			&DKIMResult{Value: ResultFail, Identifier: "@newyork.example.com"},
 		},
 	},
+	{
+		value: "example.com;" +
+			" bimi=pass header.d=mail-router.example.net",
+		identifier: "example.com",
+		results: []Result{
+			&BIMIResult{Value: ResultPass, Domain: "mail-router.example.net"},
+		},
+	},
+	{
+		value: "example.com;" +
+			" bimi=fail header.d=example.com",
+		identifier: "example.com",
+		results: []Result{
+			&BIMIResult{Value: ResultFail, Domain: "example.com"},
+		},
+	},
 }

--- a/authres/parse.go
+++ b/authres/parse.go
@@ -16,6 +16,7 @@ const (
 	ResultNone      ResultValue = "none"
 	ResultPass                  = "pass"
 	ResultFail                  = "fail"
+	ResultDeclined              = "declined"
 	ResultPolicy                = "policy"
 	ResultNeutral               = "neutral"
 	ResultTempError             = "temperror"
@@ -224,6 +225,28 @@ func (r *ARCResult) format() (ResultValue, map[string]string) {
 	}
 }
 
+type BIMIResult struct {
+	Value      ResultValue
+	Reason     string
+	Domain     string
+	Identifier string
+}
+
+func (r *BIMIResult) parse(value ResultValue, params map[string]string) error {
+	r.Value = value
+	r.Reason = params["reason"]
+	r.Domain = params["header.d"]
+	r.Identifier = params["header.i"]
+	return nil
+}
+
+func (r *BIMIResult) format() (ResultValue, map[string]string) {
+	return r.Value, map[string]string{
+		"reason":   r.Reason,
+		"header.d": r.Domain,
+		"header.i": r.Identifier,
+	}
+}
 type GenericResult struct {
 	Method string
 	Value  ResultValue
@@ -266,6 +289,9 @@ var results = map[string]newResultFunc{
 	},
 	"dmarc": func() Result {
 		return new(DMARCResult)
+	},
+	"bimi": func() Result {
+		return new(BIMIResult)
 	},
 }
 

--- a/authres/parse.go
+++ b/authres/parse.go
@@ -227,24 +227,21 @@ func (r *ARCResult) format() (ResultValue, map[string]string) {
 
 type BIMIResult struct {
 	Value      ResultValue
-	Reason     string
 	Domain     string
-	Identifier string
+	Selector string
 }
 
 func (r *BIMIResult) parse(value ResultValue, params map[string]string) error {
 	r.Value = value
-	r.Reason = params["reason"]
 	r.Domain = params["header.d"]
-	r.Identifier = params["header.i"]
+	r.Selector = params["header.selector"]
 	return nil
 }
 
 func (r *BIMIResult) format() (ResultValue, map[string]string) {
 	return r.Value, map[string]string{
-		"reason":   r.Reason,
 		"header.d": r.Domain,
-		"header.i": r.Identifier,
+		"header.selector": r.Selector,
 	}
 }
 type GenericResult struct {


### PR DESCRIPTION
#### Add BIMI support to Authentication-Results parsing

This PR adds first-class BIMI (bimi=) support to go-msgauth’s Authentication-Results parser, aligned with [RFC](https://datatracker.ietf.org/doc/html/draft-brand-indicators-for-message-identification) and the BIMI specification examples.

### What’s included

- Introduces a new BimiResult type implementing authres.Result
- Adds bimi to the supported authentication methods
- Parses and formats the following BIMI fields: bimi result values: pass, fail, none, declined
    header.d (domain where the BIMI record was found)


### Why this change

BIMI results are increasingly added by receiving MTAs to the Authentication-Results header, but go-msgauth currently treats them as generic results. This PR enables structured access to BIMI outcomes, similar to existing DKIM and DMARC support.

### RFC alignment

Implementation follows the BIMI specification examples:

- Appendix A – Selector discovery and fallback behavior
- Appendix B – Authentication-Results examples (bimi=pass, bimi=none, bimi=declined)
- Appendix C – BIMI results appended alongside SPF/DKIM/DMARC

### Notably:
reason= is intentionally not parsed, as it is not defined for BIMI
header.selector is only present when applicable (e.g. pass)

Example
```
Authentication-Results: example.com;
  dkim=pass header.d=example.com;
  dmarc=pass header.from=example.com;
  bimi=pass header.d=example.com header.selector=brand
```

### Backward compatibility
Existing parsing behavior is unchanged
Unknown auth methods continue to fall back to GenericResult